### PR TITLE
Add address and port to options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,6 +227,9 @@ function AposSite(options) {
         collections: (options.db && options.db.collections) || []
       },
 
+      address: options.address,
+      port: options.port,
+
       // Supplies LESS middleware
       static: self.rootDir + '/public',
 


### PR DESCRIPTION
Passing address and port to appy when initializing app. Helps
reduce the need for a seperate address/port file if desired.
Appy will still set a default address/port if they are not
specified.